### PR TITLE
Torte timestampsInSnapshots support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ firebase.initializeApp(config)
 
 const auth = firebase.auth()
 const firestore = firebase.firestore()
+
+// Torte expects timestampsInSnapshots to be 'true'
+firestore.settings({ timestampsInSnapshots: true })
+
 Torte.initialize(firestore)
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/starhoshi/torte#readme",
   "devDependencies": {
     "@google-cloud/firestore": "^0.14.1",
-    "@star__hoshi/tart": "^0.5.0",
+    "@star__hoshi/tart": "^0.10.0",
     "@types/jest": "^23.1.1",
     "firebase": "^5.0.4",
     "firebase-tools": "^3.18.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export class Snapshot<T extends Tart.Timestamps> {
   constructor(a: any, b?: any) {
     if (b === null || b === undefined) {
       this.ref = a.ref
-      this.data = a.data() as T
+      this.data = convertToOutput(a.data() as T)
     } else {
       this.ref = a
       this.data = b
@@ -45,32 +45,32 @@ export class Snapshot<T extends Tart.Timestamps> {
 
   save() {
     this.setCreatedDate()
-    return this.ref.set(this.data)
+    return this.ref.set(convertToInput(this.data))
   }
 
   saveWithBatch(batch: firebase.firestore.WriteBatch) {
     this.setCreatedDate()
-    batch.set(this.ref, this.data)
+    batch.set(this.ref, convertToInput(this.data))
   }
 
   saveReferenceCollection<S extends Tart.Timestamps>(collectionName: string, snapshot: Snapshot<S>) {
     const rc = this.ref.collection(collectionName).doc(snapshot.ref.id)
-    return rc.set({ createdAt: new Date(), updatedAt: new Date() })
+    return rc.set(convertToInput({ createdAt: new Date(), updatedAt: new Date() }))
   }
 
   saveReferenceCollectionWithBatch<S extends Tart.Timestamps>(batch: firebase.firestore.WriteBatch, collectionName: string, snapshot: Snapshot<S>) {
     const rc = this.ref.collection(collectionName).doc(snapshot.ref.id)
-    batch.set(rc, { createdAt: new Date(), updatedAt: new Date() })
+    batch.set(rc, convertToInput({ createdAt: new Date(), updatedAt: new Date() }))
   }
 
   saveNestedCollection<S extends Tart.Timestamps>(collectionName: string, snapshot: Snapshot<S>) {
     const rc = this.ref.collection(collectionName).doc(snapshot.ref.id)
-    return rc.set(snapshot.data)
+    return rc.set(convertToInput(snapshot.data))
   }
 
   saveNestedCollectionWithBatch<S extends Tart.Timestamps>(batch: firebase.firestore.WriteBatch, collectionName: string, snapshot: Snapshot<S>) {
     const rc = this.ref.collection(collectionName).doc(snapshot.ref.id)
-    batch.set(rc, snapshot.data)
+    batch.set(rc, convertToInput(snapshot.data))
   }
 
   async fetchNestedCollections<S extends Tart.Timestamps>(collectionName: string) {
@@ -86,7 +86,7 @@ export class Snapshot<T extends Tart.Timestamps> {
     Object.keys(data).forEach(key => {
       this.data[key] = data[key]
     })
-    return this.ref.update(data)
+    return this.ref.update(convertToInput(data))
   }
 
   updateWithBatch(batch: firebase.firestore.WriteBatch, data: Partial<T>) {
@@ -94,7 +94,7 @@ export class Snapshot<T extends Tart.Timestamps> {
     Object.keys(data).forEach(key => {
       this.data[key] = data[key]
     })
-    batch.update(this.ref, data)
+    batch.update(this.ref, convertToInput(data))
   }
 
   delete() {
@@ -127,4 +127,40 @@ export const fetch = async <T extends Tart.Timestamps>(pathOrDocumentReference: 
     throw Error(`${ds.ref.path} is not found.`)
   }
   return new Snapshot<T>(ds)
+}
+
+const convertToInput = <T extends Tart.Timestamps>(data: T) => {
+  let result: any = {}
+
+  for (let attr in data) {
+    if (data[attr] instanceof Date) {
+      if (!data[attr]) {
+        continue
+      }
+      const date = data[attr] as any as Date
+      result[attr] = firebase.firestore.Timestamp.fromDate(date)
+    } else {
+      result[attr] = data[attr]
+    }
+  }
+
+  return result
+}
+
+const convertToOutput = <T extends Tart.Timestamps>(data: T) => {
+  let result: any = {}
+
+  for (let attr in data) {
+    if (data[attr] instanceof firebase.firestore.Timestamp) {
+      if (!data[attr]) {
+        continue
+      }
+      const date = data[attr] as any as firebase.firestore.Timestamp
+      result[attr] = date.toDate()
+    } else {
+      result[attr] = data[attr]
+    }
+  }
+
+  return result
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,9 +292,9 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@star__hoshi/tart@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@star__hoshi/tart/-/tart-0.5.0.tgz#a261dad13e57561e337a928cc4568c1972b32052"
+"@star__hoshi/tart@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@star__hoshi/tart/-/tart-0.10.0.tgz#b2b6042de68539df54213f96f4765fdbcbe9b8b8"
 
 "@types/caseless@*":
   version "0.12.1"


### PR DESCRIPTION
By this PR, Torte supports firestore `timestampsInSnapshots: true` setting.

Please confirm!